### PR TITLE
Fix upload page tabs and remove header/footer

### DIFF
--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Navigation from '../components/Navigation';
 import Footer from '../components/Footer';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Star } from 'lucide-react';
 
 interface Review {
   title: string;
@@ -30,26 +30,55 @@ const ReviewsPage = () => {
     setForm({ title: '', text: '', rating: 5, author: '' });
   };
 
-  const handleDelete = async (displayIndex: number) => {
-    const originalIndex = reviews.length - 1 - displayIndex;
-    await fetch(`/api/review?index=${originalIndex}`, { method: 'DELETE' });
-    setReviews(reviews.filter((_, idx) => idx !== originalIndex));
-  };
 
   return (
-    <div className="min-h-screen bg-black">
+    <div className="min-h-screen bg-gradient-to-b from-black via-royal-violet-dark to-black">
       <Navigation />
-      <div className="pt-24 container mx-auto px-6">
+      <div className="pt-24 pb-10 container mx-auto px-6">
         <a href="/" className="flex items-center text-coral-pink hover:text-white mb-6">
           <ArrowLeft className="mr-2" size={20} /> Back
         </a>
         <form onSubmit={handleSubmit} className="max-w-md mx-auto glassmorphism p-6 rounded-xl text-white">
-          <h2 className="text-xl mb-4">Add Review</h2>
-          <input value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} placeholder="Title" className="w-full mb-2 p-2" />
-          <textarea value={form.text} onChange={e => setForm({ ...form, text: e.target.value })} placeholder="Description" className="w-full mb-2 p-2" />
-          <input value={form.author} onChange={e => setForm({ ...form, author: e.target.value })} placeholder="Author" className="w-full mb-2 p-2" />
-          <input type="number" min="1" max="5" value={form.rating} onChange={e => setForm({ ...form, rating: Number(e.target.value) })} className="w-full mb-4 p-2" />
-          <button type="submit" className="px-4 py-2 bg-coral-pink text-white rounded">Submit</button>
+          <h2 className="text-xl mb-4 text-center font-semibold">Add Review</h2>
+          <input
+            value={form.title}
+            onChange={e => setForm({ ...form, title: e.target.value })}
+            placeholder="Title"
+            className="w-full mb-2 p-2 bg-black/40 rounded"
+          />
+          <textarea
+            value={form.text}
+            onChange={e => setForm({ ...form, text: e.target.value })}
+            placeholder="Description"
+            className="w-full mb-2 p-2 bg-black/40 rounded"
+          />
+          <input
+            value={form.author}
+            onChange={e => setForm({ ...form, author: e.target.value })}
+            placeholder="Author"
+            className="w-full mb-2 p-2 bg-black/40 rounded"
+          />
+          <div className="flex justify-center mb-4 space-x-1">
+            {[1, 2, 3, 4, 5].map(n => (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setForm({ ...form, rating: n })}
+              >
+                <Star
+                  size={20}
+                  className={
+                    n <= form.rating
+                      ? 'text-champagne-gold'
+                      : 'text-gray-500'
+                  }
+                />
+              </button>
+            ))}
+          </div>
+          <button type="submit" className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors">
+            Submit
+          </button>
         </form>
       </div>
       <Footer />

--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import Navigation from '../components/Navigation';
-import Footer from '../components/Footer';
-import { ArrowLeft, Star } from 'lucide-react';
+import React, { useState, useEffect } from "react";
+import Navigation from "../components/Navigation";
+import Footer from "../components/Footer";
+import { ArrowLeft, Star } from "lucide-react";
 
 interface Review {
   title: string;
@@ -11,55 +11,65 @@ interface Review {
 }
 
 const ReviewsPage = () => {
-  const [form, setForm] = useState({ title: '', text: '', rating: 5, author: '' });
+  const [form, setForm] = useState({
+    title: "",
+    text: "",
+    rating: 5,
+    author: "",
+  });
 
   useEffect(() => {
-    fetch('/api/reviews')
-      .then(res => res.json())
+    fetch("/api/reviews")
+      .then((res) => res.json())
       .then(() => {});
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch('/api/review', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    await fetch("/api/review", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(form),
     });
     // review list managed in admin page
-    setForm({ title: '', text: '', rating: 5, author: '' });
+    setForm({ title: "", text: "", rating: 5, author: "" });
   };
-
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-black via-royal-violet-dark to-black">
       <Navigation />
       <div className="pt-24 pb-10 container mx-auto px-6">
-        <a href="/" className="flex items-center text-coral-pink hover:text-white mb-6">
+        <a
+          href="/"
+          className="flex items-center text-coral-pink hover:text-white mb-6"
+        >
           <ArrowLeft className="mr-2" size={20} /> Back
         </a>
-        <form onSubmit={handleSubmit} className="max-w-md mx-auto glassmorphism p-6 rounded-xl text-white">
+        <form
+          onSubmit={handleSubmit}
+          className="max-w-md mx-auto glassmorphism p-6 rounded-xl text-white"
+        >
           <h2 className="text-xl mb-4 text-center font-semibold">Add Review</h2>
           <input
             value={form.title}
-            onChange={e => setForm({ ...form, title: e.target.value })}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
             placeholder="Title"
             className="w-full mb-2 p-2 bg-black/40 rounded"
           />
           <textarea
             value={form.text}
-            onChange={e => setForm({ ...form, text: e.target.value })}
+            onChange={(e) => setForm({ ...form, text: e.target.value })}
             placeholder="Description"
             className="w-full mb-2 p-2 bg-black/40 rounded"
           />
           <input
             value={form.author}
-            onChange={e => setForm({ ...form, author: e.target.value })}
+            onChange={(e) => setForm({ ...form, author: e.target.value })}
             placeholder="Author"
             className="w-full mb-2 p-2 bg-black/40 rounded"
           />
           <div className="flex justify-center mb-4 space-x-1">
-            {[1, 2, 3, 4, 5].map(n => (
+            {[1, 2, 3, 4, 5].map((n) => (
               <button
                 key={n}
                 type="button"
@@ -68,15 +78,16 @@ const ReviewsPage = () => {
                 <Star
                   size={20}
                   className={
-                    n <= form.rating
-                      ? 'text-champagne-gold'
-                      : 'text-gray-500'
+                    n <= form.rating ? "text-champagne-gold" : "text-gray-500"
                   }
                 />
               </button>
             ))}
           </div>
-          <button type="submit" className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors">
+          <button
+            type="submit"
+            className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors"
+          >
             Submit
           </button>
         </form>

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -1,6 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import Navigation from '../components/Navigation';
-import Footer from '../components/Footer';
 
 const UploadPage = () => {
   const [loggedIn, setLoggedIn] = useState(false);
@@ -107,15 +105,27 @@ const handleImageSubmit = async (e: React.FormEvent) => {
   };
 
   return (
-    <div className="min-h-screen bg-black">
-      <Navigation />
-      <div className="pt-24 container mx-auto px-6">
+    <div className="min-h-screen bg-gradient-to-b from-black via-royal-violet-dark to-black pt-10">
+      <div className="container mx-auto px-6 pb-10">
         {!loggedIn ? (
           <form onSubmit={handleLogin} className="max-w-md mx-auto glassmorphism p-6 rounded-xl">
-            <h2 className="text-white mb-4 text-xl">Admin Login</h2>
-            <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className="w-full mb-2 p-2" />
-            <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="w-full mb-4 p-2" />
-            <button className="px-4 py-2 bg-coral-pink text-white rounded" type="submit">Login</button>
+            <h2 className="text-white mb-4 text-xl text-center font-semibold">Admin Login</h2>
+            <input
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              placeholder="Username"
+              className="w-full mb-2 p-2 bg-black/40 rounded text-white"
+            />
+            <input
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder="Password"
+              className="w-full mb-4 p-2 bg-black/40 rounded text-white"
+            />
+            <button className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors" type="submit">
+              Login
+            </button>
           </form>
         ) : (
           <>
@@ -124,7 +134,7 @@ const handleImageSubmit = async (e: React.FormEvent) => {
                 <button
                   key={tab}
                   onClick={() => setActiveTab(tab)}
-                  className={`px-4 py-2 rounded-full ${activeTab === tab ? 'bg-coral-pink text-white' : 'glassmorphism text-white'}`}
+                  className={`px-4 py-2 rounded-full transition-colors duration-300 ${activeTab === tab ? 'bg-coral-pink text-white' : 'glassmorphism text-white hover:bg-coral-pink/20'}`}
                 >
                   {tab}
                 </button>
@@ -134,18 +144,28 @@ const handleImageSubmit = async (e: React.FormEvent) => {
             {activeTab === 'images' && (
               <>
                 <form onSubmit={handleImageSubmit} className="max-w-md mx-auto glassmorphism p-6 rounded-xl mb-12">
-                  <h2 className="text-white mb-4 text-xl">Upload Image</h2>
-                  <select className="w-full mb-2 p-2" value={form.eventType} onChange={e => setForm({ ...form, eventType: e.target.value })}>
+                  <h2 className="text-white mb-4 text-xl text-center font-semibold">Upload Image</h2>
+                  <select className="w-full mb-2 p-2 bg-black/40 rounded text-white" value={form.eventType} onChange={e => setForm({ ...form, eventType: e.target.value })}>
                     <option value="concert">concert</option>
                     <option value="corporate">corporate</option>
                     <option value="crowd">crowd</option>
                     <option value="wedding">wedding</option>
                     <option value="random">random</option>
                   </select>
-                  <input value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} placeholder="Title" className="w-full mb-2 p-2" />
-                  <textarea value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} placeholder="Description" className="w-full mb-2 p-2" />
-                  <input type="file" onChange={e => setForm({ ...form, image: e.target.files ? e.target.files[0] : null })} className="w-full mb-4" />
-                  <button className="px-4 py-2 bg-coral-pink text-white rounded" type="submit">Upload</button>
+                  <input
+                    value={form.title}
+                    onChange={e => setForm({ ...form, title: e.target.value })}
+                    placeholder="Title"
+                    className="w-full mb-2 p-2 bg-black/40 rounded text-white"
+                  />
+                  <textarea
+                    value={form.description}
+                    onChange={e => setForm({ ...form, description: e.target.value })}
+                    placeholder="Description"
+                    className="w-full mb-2 p-2 bg-black/40 rounded text-white"
+                  />
+                  <input type="file" onChange={e => setForm({ ...form, image: e.target.files ? e.target.files[0] : null })} className="w-full mb-4 text-white" />
+                  <button className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors" type="submit">Upload</button>
                 </form>
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                   {[...items].reverse().map(item => (
@@ -166,16 +186,31 @@ const handleImageSubmit = async (e: React.FormEvent) => {
             {activeTab === 'events' && (
               <>
                 <form onSubmit={handleEventSubmit} className="max-w-md mx-auto glassmorphism p-6 rounded-xl mb-12">
-                  <h2 className="text-white mb-4 text-xl">Add Event</h2>
-                  <input value={eventForm.title} onChange={e => setEventForm({ ...eventForm, title: e.target.value })} placeholder="Event Name" className="w-full mb-2 p-2" />
-                  <input type="date" value={eventForm.date} onChange={e => setEventForm({ ...eventForm, date: e.target.value })} className="w-full mb-2 p-2" />
-                  <textarea value={eventForm.description} onChange={e => setEventForm({ ...eventForm, description: e.target.value })} placeholder="Description (optional)" className="w-full mb-2 p-2" />
-                  <input type="file" onChange={e => setEventForm({ ...eventForm, image: e.target.files ? e.target.files[0] : null })} className="w-full mb-4" />
-                  <button className="px-4 py-2 bg-coral-pink text-white rounded" type="submit">Upload</button>
+                  <h2 className="text-white mb-4 text-xl text-center font-semibold">Add Event</h2>
+                  <input
+                    value={eventForm.title}
+                    onChange={e => setEventForm({ ...eventForm, title: e.target.value })}
+                    placeholder="Event Name"
+                    className="w-full mb-2 p-2 bg-black/40 rounded text-white"
+                  />
+                  <input
+                    type="date"
+                    value={eventForm.date}
+                    onChange={e => setEventForm({ ...eventForm, date: e.target.value })}
+                    className="w-full mb-2 p-2 bg-black/40 rounded text-white"
+                  />
+                  <textarea
+                    value={eventForm.description}
+                    onChange={e => setEventForm({ ...eventForm, description: e.target.value })}
+                    placeholder="Description (optional)"
+                    className="w-full mb-2 p-2 bg-black/40 rounded text-white"
+                  />
+                  <input type="file" onChange={e => setEventForm({ ...eventForm, image: e.target.files ? e.target.files[0] : null })} className="w-full mb-4 text-white" />
+                  <button className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors" type="submit">Upload</button>
                 </form>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                   {[...events].reverse().map((ev, idx) => (
-                    <div key={idx} className="glassmorphism p-4 rounded-xl relative text-white">
+                    <div key={idx} className="glassmorphism p-4 rounded-xl relative text-white transform-gpu hover:scale-105 transition-transform">
                       <button
                         className="absolute top-1 right-1 bg-black/50 text-white rounded-full w-6 h-6 flex items-center justify-center"
                         onClick={() => handleEventDelete(idx)}
@@ -194,7 +229,7 @@ const handleImageSubmit = async (e: React.FormEvent) => {
             {activeTab === 'reviews' && (
               <div className="grid md:grid-cols-3 gap-4">
                 {[...reviews].reverse().map((rev, idx) => (
-                  <div key={idx} className="glassmorphism p-4 rounded-xl relative text-white">
+                  <div key={idx} className="glassmorphism p-4 rounded-xl relative text-white transform-gpu hover:scale-105 transition-transform">
                     <button
                       className="absolute top-1 right-1 bg-black/50 text-white rounded-full w-6 h-6 flex items-center justify-center"
                       onClick={() => handleReviewDelete(idx)}
@@ -206,7 +241,7 @@ const handleImageSubmit = async (e: React.FormEvent) => {
                     <p className="text-sm mb-2">- {rev.author}</p>
                     <div className="flex space-x-1">
                       {Array.from({ length: rev.rating }).map((_, i) => (
-                        <span key={i}>⭐</span>
+                        <span key={i} className="text-champagne-gold">⭐</span>
                       ))}
                     </div>
                   </div>
@@ -215,23 +250,7 @@ const handleImageSubmit = async (e: React.FormEvent) => {
             )}
           </>
         )}
-        {loggedIn && (
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[...items].reverse().map(item => (
-              <div key={item.src} className="relative">
-                <button
-                  className="absolute top-1 right-1 bg-black/50 text-white rounded-full w-6 h-6 flex items-center justify-center"
-                  onClick={() => handleDelete(item.src)}
-                >
-                  ×
-                </button>
-                <img src={item.src} className="w-full h-32 object-cover rounded" />
-              </div>
-            ))}
-          </div>
-        )}
       </div>
-      <Footer />
     </div>
   );
 };

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -1,44 +1,56 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 
 const UploadPage = () => {
   const [loggedIn, setLoggedIn] = useState(false);
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [activeTab, setActiveTab] = useState<'images' | 'events' | 'reviews'>('images');
-  const [form, setForm] = useState({ eventType: 'concert', title: '', description: '', image: null as File | null });
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [activeTab, setActiveTab] = useState<"images" | "events" | "reviews">(
+    "images",
+  );
+  const [form, setForm] = useState({
+    eventType: "concert",
+    title: "",
+    description: "",
+    image: null as File | null,
+  });
   const [items, setItems] = useState<any[]>([]);
   const [events, setEvents] = useState<any[]>([]);
-  const [eventForm, setEventForm] = useState({ title: '', date: '', description: '', image: null as File | null });
+  const [eventForm, setEventForm] = useState({
+    title: "",
+    date: "",
+    description: "",
+    image: null as File | null,
+  });
   const [reviews, setReviews] = useState<any[]>([]);
 
   useEffect(() => {
     if (loggedIn) {
-      fetch('/api/gallery')
-        .then(res => res.json())
-        .then(data => setItems(data));
-      fetch('/api/events')
-        .then(res => res.json())
-        .then(data => setEvents(data));
-      fetch('/api/reviews')
-        .then(res => res.json())
-        .then(data => setReviews(data));
+      fetch("/api/gallery")
+        .then((res) => res.json())
+        .then((data) => setItems(data));
+      fetch("/api/events")
+        .then((res) => res.json())
+        .then((data) => setEvents(data));
+      fetch("/api/reviews")
+        .then((res) => res.json())
+        .then((data) => setReviews(data));
     }
   }, [loggedIn]);
   const handleLogin = (e: React.FormEvent) => {
     e.preventDefault();
-    if (username === 'admin' && password === 'nisarga123') {
+    if (username === "admin" && password === "nisarga123") {
       setLoggedIn(true);
     } else {
-      alert('Invalid credentials');
+      alert("Invalid credentials");
     }
   };
 
-const handleImageSubmit = async (e: React.FormEvent) => {
+  const handleImageSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!form.image) return;
 
     if (form.image.size > 25 * 1024 * 1024) {
-      alert('File is larger than 25MB');
+      alert("File is larger than 25MB");
       return;
     }
 
@@ -48,23 +60,25 @@ const handleImageSubmit = async (e: React.FormEvent) => {
         eventType: form.eventType,
         title: form.title,
         description: form.description,
-        image: (reader.result as string).split(',')[1],
+        image: (reader.result as string).split(",")[1],
       };
-      await fetch('/api/upload', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      await fetch("/api/upload", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
-      const itemsRes = await fetch('/api/gallery');
+      const itemsRes = await fetch("/api/gallery");
       setItems(await itemsRes.json());
-      alert('Uploaded');
+      alert("Uploaded");
     };
     reader.readAsDataURL(form.image);
   };
 
   const handleDelete = async (src: string) => {
-    await fetch(`/api/gallery?src=${encodeURIComponent(src)}`, { method: 'DELETE' });
-    setItems(items.filter(item => item.src !== src));
+    await fetch(`/api/gallery?src=${encodeURIComponent(src)}`, {
+      method: "DELETE",
+    });
+    setItems(items.filter((item) => item.src !== src));
   };
 
   const handleEventSubmit = async (e: React.FormEvent) => {
@@ -77,30 +91,30 @@ const handleImageSubmit = async (e: React.FormEvent) => {
         title: eventForm.title,
         date: eventForm.date,
         description: eventForm.description,
-        image: (reader.result as string).split(',')[1],
+        image: (reader.result as string).split(",")[1],
       };
-      await fetch('/api/event', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      await fetch("/api/event", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
-      fetch('/api/events')
-        .then(res => res.json())
-        .then(data => setEvents(data));
-      alert('Uploaded');
+      fetch("/api/events")
+        .then((res) => res.json())
+        .then((data) => setEvents(data));
+      alert("Uploaded");
     };
     reader.readAsDataURL(eventForm.image);
   };
 
   const handleEventDelete = async (displayIndex: number) => {
     const originalIndex = events.length - 1 - displayIndex;
-    await fetch(`/api/event?index=${originalIndex}`, { method: 'DELETE' });
+    await fetch(`/api/event?index=${originalIndex}`, { method: "DELETE" });
     setEvents(events.filter((_, i) => i !== originalIndex));
   };
 
   const handleReviewDelete = async (displayIndex: number) => {
     const originalIndex = reviews.length - 1 - displayIndex;
-    await fetch(`/api/review?index=${originalIndex}`, { method: 'DELETE' });
+    await fetch(`/api/review?index=${originalIndex}`, { method: "DELETE" });
     setReviews(reviews.filter((_, idx) => idx !== originalIndex));
   };
 
@@ -108,44 +122,75 @@ const handleImageSubmit = async (e: React.FormEvent) => {
     <div className="min-h-screen bg-gradient-to-b from-black via-royal-violet-dark to-black pt-10">
       <div className="container mx-auto px-6 pb-10">
         {!loggedIn ? (
-          <form onSubmit={handleLogin} className="max-w-md mx-auto glassmorphism p-6 rounded-xl">
-            <h2 className="text-white mb-4 text-xl text-center font-semibold">Admin Login</h2>
+          <form
+            onSubmit={handleLogin}
+            className="max-w-md mx-auto glassmorphism p-6 rounded-xl"
+          >
+            <h2 className="text-white mb-4 text-xl text-center font-semibold">
+              Admin Login
+            </h2>
             <input
               value={username}
-              onChange={e => setUsername(e.target.value)}
+              onChange={(e) => setUsername(e.target.value)}
               placeholder="Username"
               className="w-full mb-2 p-2 bg-black/40 rounded text-white"
             />
             <input
               type="password"
               value={password}
-              onChange={e => setPassword(e.target.value)}
+              onChange={(e) => setPassword(e.target.value)}
               placeholder="Password"
               className="w-full mb-4 p-2 bg-black/40 rounded text-white"
             />
-            <button className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors" type="submit">
+            <button
+              className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors"
+              type="submit"
+            >
               Login
             </button>
           </form>
         ) : (
           <>
-            <div className="flex space-x-4 mb-6 justify-center">
-              {(['images', 'events', 'reviews'] as const).map(tab => (
-                <button
-                  key={tab}
-                  onClick={() => setActiveTab(tab)}
-                  className={`px-4 py-2 rounded-full transition-colors duration-300 ${activeTab === tab ? 'bg-coral-pink text-white' : 'glassmorphism text-white hover:bg-coral-pink/20'}`}
-                >
-                  {tab}
-                </button>
-              ))}
+            <div className="flex justify-between items-center mb-6">
+              <button
+                className="text-white underline hover:text-coral-pink"
+                onClick={() => {
+                  setLoggedIn(false);
+                  setUsername("");
+                  setPassword("");
+                }}
+              >
+                Logout
+              </button>
+              <div className="flex space-x-4">
+                {(["images", "events", "reviews"] as const).map((tab) => (
+                  <button
+                    key={tab}
+                    onClick={() => setActiveTab(tab)}
+                    className={`px-4 py-2 rounded-full transition-colors duration-300 ${activeTab === tab ? "bg-coral-pink text-white" : "glassmorphism text-white hover:bg-coral-pink/20"}`}
+                  >
+                    {tab}
+                  </button>
+                ))}
+              </div>
             </div>
 
-            {activeTab === 'images' && (
+            {activeTab === "images" && (
               <>
-                <form onSubmit={handleImageSubmit} className="max-w-md mx-auto glassmorphism p-6 rounded-xl mb-12">
-                  <h2 className="text-white mb-4 text-xl text-center font-semibold">Upload Image</h2>
-                  <select className="w-full mb-2 p-2 bg-black/40 rounded text-white" value={form.eventType} onChange={e => setForm({ ...form, eventType: e.target.value })}>
+                <form
+                  onSubmit={handleImageSubmit}
+                  className="max-w-md mx-auto glassmorphism p-6 rounded-xl mb-12"
+                >
+                  <h2 className="text-white mb-4 text-xl text-center font-semibold">
+                    Upload Image
+                  </h2>
+                  <select
+                    className="w-full mb-2 p-2 bg-black/40 rounded text-white"
+                    value={form.eventType}
+                    onChange={(e) =>
+                      setForm({ ...form, eventType: e.target.value })
+                    }
+                  >
                     <option value="concert">concert</option>
                     <option value="corporate">corporate</option>
                     <option value="crowd">crowd</option>
@@ -154,21 +199,39 @@ const handleImageSubmit = async (e: React.FormEvent) => {
                   </select>
                   <input
                     value={form.title}
-                    onChange={e => setForm({ ...form, title: e.target.value })}
+                    onChange={(e) =>
+                      setForm({ ...form, title: e.target.value })
+                    }
                     placeholder="Title"
                     className="w-full mb-2 p-2 bg-black/40 rounded text-white"
                   />
                   <textarea
                     value={form.description}
-                    onChange={e => setForm({ ...form, description: e.target.value })}
+                    onChange={(e) =>
+                      setForm({ ...form, description: e.target.value })
+                    }
                     placeholder="Description"
                     className="w-full mb-2 p-2 bg-black/40 rounded text-white"
                   />
-                  <input type="file" onChange={e => setForm({ ...form, image: e.target.files ? e.target.files[0] : null })} className="w-full mb-4 text-white" />
-                  <button className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors" type="submit">Upload</button>
+                  <input
+                    type="file"
+                    onChange={(e) =>
+                      setForm({
+                        ...form,
+                        image: e.target.files ? e.target.files[0] : null,
+                      })
+                    }
+                    className="w-full mb-4 text-white"
+                  />
+                  <button
+                    className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors"
+                    type="submit"
+                  >
+                    Upload
+                  </button>
                 </form>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  {[...items].reverse().map(item => (
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+                  {[...items].reverse().map((item) => (
                     <div key={item.src} className="relative">
                       <button
                         className="absolute top-1 right-1 bg-black/50 text-white rounded-full w-6 h-6 flex items-center justify-center"
@@ -176,48 +239,85 @@ const handleImageSubmit = async (e: React.FormEvent) => {
                       >
                         ×
                       </button>
-                      <img src={item.src} className="w-full h-32 object-cover rounded" />
+                      <img
+                        src={item.src}
+                        className="w-full h-32 object-cover rounded"
+                      />
                     </div>
                   ))}
                 </div>
               </>
             )}
 
-            {activeTab === 'events' && (
+            {activeTab === "events" && (
               <>
-                <form onSubmit={handleEventSubmit} className="max-w-md mx-auto glassmorphism p-6 rounded-xl mb-12">
-                  <h2 className="text-white mb-4 text-xl text-center font-semibold">Add Event</h2>
+                <form
+                  onSubmit={handleEventSubmit}
+                  className="max-w-md mx-auto glassmorphism p-6 rounded-xl mb-12"
+                >
+                  <h2 className="text-white mb-4 text-xl text-center font-semibold">
+                    Add Event
+                  </h2>
                   <input
                     value={eventForm.title}
-                    onChange={e => setEventForm({ ...eventForm, title: e.target.value })}
+                    onChange={(e) =>
+                      setEventForm({ ...eventForm, title: e.target.value })
+                    }
                     placeholder="Event Name"
                     className="w-full mb-2 p-2 bg-black/40 rounded text-white"
                   />
                   <input
                     type="date"
                     value={eventForm.date}
-                    onChange={e => setEventForm({ ...eventForm, date: e.target.value })}
+                    onChange={(e) =>
+                      setEventForm({ ...eventForm, date: e.target.value })
+                    }
                     className="w-full mb-2 p-2 bg-black/40 rounded text-white"
                   />
                   <textarea
                     value={eventForm.description}
-                    onChange={e => setEventForm({ ...eventForm, description: e.target.value })}
+                    onChange={(e) =>
+                      setEventForm({
+                        ...eventForm,
+                        description: e.target.value,
+                      })
+                    }
                     placeholder="Description (optional)"
                     className="w-full mb-2 p-2 bg-black/40 rounded text-white"
                   />
-                  <input type="file" onChange={e => setEventForm({ ...eventForm, image: e.target.files ? e.target.files[0] : null })} className="w-full mb-4 text-white" />
-                  <button className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors" type="submit">Upload</button>
+                  <input
+                    type="file"
+                    onChange={(e) =>
+                      setEventForm({
+                        ...eventForm,
+                        image: e.target.files ? e.target.files[0] : null,
+                      })
+                    }
+                    className="w-full mb-4 text-white"
+                  />
+                  <button
+                    className="w-full py-2 bg-coral-pink rounded text-white font-medium hover:bg-coral-pink/80 transition-colors"
+                    type="submit"
+                  >
+                    Upload
+                  </button>
                 </form>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
                   {[...events].reverse().map((ev, idx) => (
-                    <div key={idx} className="glassmorphism p-4 rounded-xl relative text-white transform-gpu hover:scale-105 transition-transform">
+                    <div
+                      key={idx}
+                      className="glassmorphism p-4 rounded-xl relative text-white transform-gpu hover:scale-105 transition-transform"
+                    >
                       <button
                         className="absolute top-1 right-1 bg-black/50 text-white rounded-full w-6 h-6 flex items-center justify-center"
                         onClick={() => handleEventDelete(idx)}
                       >
                         ×
                       </button>
-                      <img src={ev.image} className="w-full h-32 object-cover rounded mb-2" />
+                      <img
+                        src={ev.image}
+                        className="w-full h-32 object-cover rounded mb-2"
+                      />
                       <h3 className="font-semibold">{ev.title}</h3>
                       <p className="text-sm text-gray-300">{ev.date}</p>
                     </div>
@@ -226,10 +326,13 @@ const handleImageSubmit = async (e: React.FormEvent) => {
               </>
             )}
 
-            {activeTab === 'reviews' && (
-              <div className="grid md:grid-cols-3 gap-4">
+            {activeTab === "reviews" && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
                 {[...reviews].reverse().map((rev, idx) => (
-                  <div key={idx} className="glassmorphism p-4 rounded-xl relative text-white transform-gpu hover:scale-105 transition-transform">
+                  <div
+                    key={idx}
+                    className="glassmorphism p-4 rounded-xl relative text-white transform-gpu hover:scale-105 transition-transform"
+                  >
                     <button
                       className="absolute top-1 right-1 bg-black/50 text-white rounded-full w-6 h-6 flex items-center justify-center"
                       onClick={() => handleReviewDelete(idx)}
@@ -241,7 +344,9 @@ const handleImageSubmit = async (e: React.FormEvent) => {
                     <p className="text-sm mb-2">- {rev.author}</p>
                     <div className="flex space-x-1">
                       {Array.from({ length: rev.rating }).map((_, i) => (
-                        <span key={i} className="text-champagne-gold">⭐</span>
+                        <span key={i} className="text-champagne-gold">
+                          ⭐
+                        </span>
                       ))}
                     </div>
                   </div>

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -152,7 +152,8 @@ const UploadPage = () => {
         ) : (
           <>
             <div className="flex justify-between items-center mb-6">
-              <button
+              <a
+                href="/"
                 className="text-white underline hover:text-coral-pink"
                 onClick={() => {
                   setLoggedIn(false);
@@ -161,7 +162,7 @@ const UploadPage = () => {
                 }}
               >
                 Logout
-              </button>
+              </a>
               <div className="flex space-x-4">
                 {(["images", "events", "reviews"] as const).map((tab) => (
                   <button


### PR DESCRIPTION
## Summary
- clean up Upload page to show only selected tab
- remove unused header/footer from the admin route
- improve styling for Upload and Reviews pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6873b694b26c832caa79611b399aad24